### PR TITLE
chore: update parent version to 15.5.0 and fix deprecated Jackson API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<properties>

--- a/src/main/java/org/codelibs/fess/ds/salesforce/api/TokenResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/salesforce/api/TokenResponse.java
@@ -16,14 +16,14 @@
 package org.codelibs.fess.ds.salesforce.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 /**
  * Represents the response from a Salesforce token request.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TokenResponse {
     /** The access token. */
     protected String accessToken;


### PR DESCRIPTION
## Summary
Update fess-parent version to the 15.5.0 release and fix a deprecated Jackson API usage.

## Changes Made
- **pom.xml**: Update `fess-parent` version from `15.5.0-SNAPSHOT` to `15.5.0`
- **TokenResponse.java**: Replace deprecated `PropertyNamingStrategy.SnakeCaseStrategy` with `PropertyNamingStrategies.SnakeCaseStrategy` (Jackson 2.12+)

## Testing
- No behavioral changes; the `PropertyNamingStrategies.SnakeCaseStrategy` is a direct replacement for the deprecated class

## Breaking Changes
- None

## Additional Notes
- `PropertyNamingStrategy` was deprecated in Jackson 2.12 in favor of `PropertyNamingStrategies`